### PR TITLE
Enhance Yellhorn MCP with Git Worktree Integration and Streamlined Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Model Context Protocol (MCP) server that exposes Gemini 2.5 Pro capabilities t
 ## Features
 
 - **Generate Work Plans**: Creates GitHub issues with detailed implementation plans based on your codebase, with customizable title and detailed description
-- **Automatic Branch Creation**: Automatically creates and links branches to work plan issues for streamlined workflow
+- **Isolated Development Environments**: Automatically creates Git worktrees and linked branches for streamlined, isolated development workflow
 - **Review Code Diffs**: Evaluates pull requests against the original work plan with full codebase context and provides detailed feedback
 - **Seamless GitHub Integration**: Automatically creates labeled issues, posts reviews as PR comments with references to original issues, and handles asynchronous processing
 - **Context Control**: Use `.yellhornignore` files to exclude specific files and directories from the AI context, similar to `.gitignore`
@@ -62,17 +62,31 @@ When working with Claude Code, you can use the Yellhorn MCP tools by:
    Please generate a work plan with title "[Your Title]" and detailed description "[Your detailed requirements]"
    ```
 
-2. Reviewing your implementation:
+2. Navigate to the created worktree directory:
 
    ```
-   Please review my changes in PR [PR URL] against the work plan from issue #[issue number]
+   cd [worktree_path]  # The path is returned in the response
+   ```
+
+3. View the work plan if needed:
+
+   ```
+   # While in the worktree directory
+   Please get the current work plan for this worktree
+   ```
+
+4. Make your changes and submit them:
+
+   ```
+   # While in the worktree directory
+   Please commit my changes and create a PR with title "[PR Title]" and body "[PR Description]"
    ```
 
 ## Tools
 
 ### generate_work_plan
 
-Creates a GitHub issue with a detailed work plan based on the title and detailed description, labeled with 'yellhorn-mcp'.
+Creates a GitHub issue with a detailed work plan based on the title and detailed description. Also creates a Git worktree with a linked branch for isolated development.
 
 **Input**:
 
@@ -81,21 +95,39 @@ Creates a GitHub issue with a detailed work plan based on the title and detailed
 
 **Output**:
 
-- URL to the created GitHub issue
+- JSON string containing:
+  - `issue_url`: URL to the created GitHub issue
+  - `worktree_path`: Path to the created Git worktree directory
 
-### review_work_plan
+### get_workplan
 
-Reviews a pull request against the original work plan and provides feedback. Includes the full codebase as context for better analysis and adds a reference to the original work plan in the review comment.
+Retrieves the work plan content (GitHub issue body) associated with the current Git worktree.
+
+**Note**: Must be run from within a worktree created by 'generate_work_plan'.
 
 **Input**:
 
-- `work_plan_issue_number`: GitHub issue number containing the work plan
-- `pull_request_url`: GitHub PR URL containing the changes to review
-- `ctx`: Server context
+- No parameters required
 
 **Output**:
 
-- Asynchronously posts a review directly to the PR with a reference to the original work plan issue
+- The content of the work plan issue as a string
+
+### submit_workplan
+
+Submits the completed work from the current Git worktree. Stages all changes, commits them, pushes the branch, creates a GitHub Pull Request, and triggers an asynchronous code review against the associated work plan issue.
+
+**Note**: Must be run from within a worktree created by 'generate_work_plan'.
+
+**Input**:
+
+- `pr_title`: Title for the GitHub Pull Request
+- `pr_body`: Body content for the GitHub Pull Request
+- `commit_message`: Optional commit message (defaults to "WIP submission for issue #X")
+
+**Output**:
+
+- The URL of the created GitHub Pull Request
 
 ## Development
 

--- a/examples/client_example.py
+++ b/examples/client_example.py
@@ -22,11 +22,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 
-async def generate_work_plan(
-    session: ClientSession, 
-    title: str, 
-    detailed_description: str
-) -> str:
+async def generate_work_plan(session: ClientSession, title: str, detailed_description: str) -> str:
     """
     Generate a work plan using the Yellhorn MCP server.
     Creates a GitHub issue and returns the issue URL.
@@ -42,10 +38,7 @@ async def generate_work_plan(
     # Call the generate_work_plan tool
     result = await session.call_tool(
         "generate_work_plan",
-        arguments={
-            "title": title,
-            "detailed_description": detailed_description
-        },
+        arguments={"title": title, "detailed_description": detailed_description},
     )
 
     # Extract the issue URL from the response
@@ -53,12 +46,12 @@ async def generate_work_plan(
 
 
 async def review_work_plan(
-    session: ClientSession, 
-    work_plan: str | None = None, 
+    session: ClientSession,
+    work_plan: str | None = None,
     diff: str | None = None,
     work_plan_issue_number: str | None = None,
     pr_url: str | None = None,
-    post_to_pr: bool = False
+    post_to_pr: bool = False,
 ) -> str:
     """
     Review a diff against a work plan using the Yellhorn MCP server.
@@ -77,28 +70,30 @@ async def review_work_plan(
 
     Returns:
         Review feedback or confirmation message.
-        
+
     Raises:
         ValueError: If neither work_plan nor work_plan_issue_number is provided.
     """
     arguments = {}
-    
+
     # Set the arguments according to server API
     if work_plan_issue_number:
         arguments["work_plan_issue_number"] = work_plan_issue_number
     elif work_plan:
         # Note: The current server implementation doesn't support raw content,
         # so we'll raise an error for now
-        raise ValueError("Raw work plan content is not supported. Please provide a work_plan_issue_number")
+        raise ValueError(
+            "Raw work plan content is not supported. Please provide a work_plan_issue_number"
+        )
     else:
         raise ValueError("work_plan_issue_number must be provided")
-    
+
     if pr_url:
         arguments["pull_request_url"] = pr_url
     else:
         # Note: The current server implementation requires a pull_request_url
         raise ValueError("pull_request_url must be provided")
-    
+
     # Call the review_work_plan tool
     await session.call_tool(
         "review_work_plan",
@@ -160,11 +155,7 @@ async def run_client(command: str, args: argparse.Namespace) -> None:
                 # Generate work plan
                 print(f"Generating work plan with title: {args.title}")
                 print(f"Detailed description: {args.description}")
-                issue_url = await generate_work_plan(
-                    session, 
-                    args.title, 
-                    args.description
-                )
+                issue_url = await generate_work_plan(session, args.title, args.description)
                 print("\nGitHub Issue Created:")
                 print(issue_url)
                 print(
@@ -177,7 +168,7 @@ async def run_client(command: str, args: argparse.Namespace) -> None:
                 work_plan_issue_number = None
                 diff = None
                 pr_url = None
-                
+
                 # Determine work plan source
                 if args.work_plan_issue_number:
                     work_plan_issue_number = args.work_plan_issue_number
@@ -185,7 +176,7 @@ async def run_client(command: str, args: argparse.Namespace) -> None:
                 else:
                     print("Error: --work-plan-issue-number must be specified")
                     sys.exit(1)
-                
+
                 # Determine PR URL (required)
                 if args.pr_url:
                     pr_url = args.pr_url
@@ -193,13 +184,11 @@ async def run_client(command: str, args: argparse.Namespace) -> None:
                 else:
                     print("Error: --pr-url must be specified")
                     sys.exit(1)
-                
+
                 # Review PR
                 print("Initiating review...")
                 result = await review_work_plan(
-                    session,
-                    work_plan_issue_number=work_plan_issue_number,
-                    pr_url=pr_url
+                    session, work_plan_issue_number=work_plan_issue_number, pr_url=pr_url
                 )
                 print("\nResult:")
                 print(result)
@@ -216,27 +205,35 @@ def main():
     # Generate work plan command
     plan_parser = subparsers.add_parser("plan", help="Generate a work plan")
     plan_parser.add_argument(
-        "--title", dest="title", required=True,
-        help="Title for the work plan (e.g., 'Implement User Authentication')"
+        "--title",
+        dest="title",
+        required=True,
+        help="Title for the work plan (e.g., 'Implement User Authentication')",
     )
     plan_parser.add_argument(
-        "--description", dest="description", required=True,
-        help="Detailed description for the work plan"
+        "--description",
+        dest="description",
+        required=True,
+        help="Detailed description for the work plan",
     )
 
     # Review PR command
     review_parser = subparsers.add_parser("review", help="Review a GitHub PR against a work plan")
-    
+
     # Work plan source (GitHub issue number required)
     review_parser.add_argument(
-        "--work-plan-issue-number", dest="work_plan_issue_number", required=True,
-        help="GitHub issue number containing the work plan"
+        "--work-plan-issue-number",
+        dest="work_plan_issue_number",
+        required=True,
+        help="GitHub issue number containing the work plan",
     )
-    
+
     # PR URL (required)
     review_parser.add_argument(
-        "--pr-url", dest="pr_url", required=True,
-        help="GitHub PR URL to review and post comments to"
+        "--pr-url",
+        dest="pr_url",
+        required=True,
+        help="GitHub PR URL to review and post comments to",
     )
 
     args = parser.parse_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yellhorn-mcp"
-version = "0.1.5"
+version = "0.2.0"
 authors = [{ name = "Author" }]
 description = "Yellhorn MCP server uses Gemini 2.5 pro to generate detailed work plans and review pull requests."
 readme = "README.md"

--- a/yellhorn_mcp/__init__.py
+++ b/yellhorn_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Yellhorn MCP server for Claude Code to interact with the Gemini 2.5 Pro API."""
 
-__version__ = "0.1.5"
+__version__ = "0.2.0"


### PR DESCRIPTION
This PR implements the changes described in issue #12:

## Features Added
- Created helper functions for working with git worktrees
- Enhanced generate_work_plan to create isolated worktrees for development
- Added get_workplan tool to retrieve work plan content from a worktree
- Added submit_workplan tool to replace review_work_plan with more streamlined workflow
- Updated documentation to reflect the new workflow

## Breaking Changes
- Removed review_work_plan tool, which is replaced by the submit_workplan functionality
- Changed the return value of generate_work_plan to include the worktree path

## Tests
- Added tests for new helper functions and tools
- Updated existing tests to work with the new workflow