### PR TITLE
Refactor generate_workplan to separate GitHub issue creation from Git…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A Model Context Protocol (MCP) server that exposes Gemini 2.5 Pro capabilities t
 
 ## Features
 
-- **Generate workplans**: Creates GitHub issues with detailed implementation plans based on your codebase, with customizable title and detailed description
-- **Isolated Development Environments**: Automatically creates Git worktrees and linked branches for streamlined, isolated development workflow
+- **Generate workplans**: Creates GitHub issues with detailed implementation plans based on your codebase, with customizable title and detailed description 
+- **Isolated Development Environments**: Creates Git worktrees and linked branches for streamlined, isolated development workflow (can be done separately from workplan generation)
 - **Review Code Diffs**: Evaluates pull requests against the original workplan with full codebase context and provides detailed feedback
 - **Seamless GitHub Integration**: Automatically creates labeled issues with proper branch linking in the GitHub UI, posts reviews as PR comments with references to original issues, and handles asynchronous processing
 - **Context Control**: Use `.yellhornignore` files to exclude specific files and directories from the AI context, similar to `.gitignore`
@@ -63,13 +63,19 @@ When working with Claude Code, you can use the Yellhorn MCP tools by:
    Please generate a workplan with title "[Your Title]" and detailed description "[Your detailed requirements]"
    ```
 
-2. Navigate to the created worktree directory:
+2. Create a worktree for the workplan (optional):
+
+   ```
+   Please create a worktree for issue #123
+   ```
+
+3. Navigate to the created worktree directory:
 
    ```
    cd [worktree_path]  # The path is returned in the response
    ```
 
-3. View the workplan if needed:
+4. View the workplan if needed:
 
    ```
    # Option 1: From the worktree directory (auto-detects issue number)
@@ -81,7 +87,7 @@ When working with Claude Code, you can use the Yellhorn MCP tools by:
    Please get the workplan for issue #123
    ```
 
-4. Make your changes, create a PR, and request a review:
+5. Make your changes, create a PR, and request a review:
 
    ```
    # First create a PR using your preferred method (Git CLI, GitHub CLI, or web UI)
@@ -103,7 +109,7 @@ When working with Claude Code, you can use the Yellhorn MCP tools by:
 
 ### generate_workplan
 
-Creates a GitHub issue with a detailed workplan based on the title and detailed description. Also creates a Git worktree with a linked branch for isolated development.
+Creates a GitHub issue with a detailed workplan based on the title and detailed description.
 
 **Input**:
 
@@ -114,7 +120,22 @@ Creates a GitHub issue with a detailed workplan based on the title and detailed 
 
 - JSON string containing:
   - `issue_url`: URL to the created GitHub issue
+  - `issue_number`: The GitHub issue number
+
+### create_worktree
+
+Creates a git worktree with a linked branch for isolated development from an existing workplan issue.
+
+**Input**:
+
+- `issue_number`: The GitHub issue number for the workplan
+
+**Output**:
+
+- JSON string containing:
   - `worktree_path`: Path to the created Git worktree directory
+  - `branch_name`: Name of the branch created for the worktree
+  - `issue_url`: URL to the associated GitHub issue
 
 ### get_workplan
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,9 +4,10 @@
 
 Yellhorn MCP is a Model Context Protocol (MCP) server that allows Claude Code to interact with the Gemini 2.5 Pro API for software development tasks. It provides these main tools:
 
-1. **Generate workplan**: Creates a GitHub issue with a detailed implementation plan based on your codebase and task description. Creates a git worktree for isolated development.
-2. **Get workplan**: Retrieves the workplan content from a worktree's associated GitHub issue.
-3. **Submit workplan**: Commits changes, pushes to GitHub, creates a PR, and triggers an asynchronous review against the original workplan.
+1. **Generate workplan**: Creates a GitHub issue with a detailed implementation plan based on your codebase and task description.
+2. **Create worktree**: Creates a git worktree with a linked branch for isolated development from an existing workplan issue.
+3. **Get workplan**: Retrieves the workplan content from a worktree's associated GitHub issue.
+4. **Review workplan**: Triggers an asynchronous code review for a Pull Request against its original workplan issue.
 
 ## Installation
 
@@ -133,17 +134,25 @@ Once the server is running, Claude Code can utilize the tools it exposes. Here's
 Please generate a workplan for implementing a user authentication system in my application.
 ```
 
-This will use the `generate_workplan` tool to analyze your codebase, create a GitHub issue, and populate it with a detailed implementation plan. It also creates a Git worktree for isolated development. The tool will return both the issue URL and worktree path. The issue will initially show a placeholder message and will be updated asynchronously once the plan is generated.
+This will use the `generate_workplan` tool to analyze your codebase, create a GitHub issue, and populate it with a detailed implementation plan. The tool will return the issue URL and number. The issue will initially show a placeholder message and will be updated asynchronously once the plan is generated.
 
-### 2. Navigate to the Worktree
+### 2. Creating a worktree (optional)
+
+```
+Please create a worktree for issue #123.
+```
+
+This will use the `create_worktree` tool to create a Git worktree with a linked branch for isolated development. The tool will return the worktree path, branch name, and issue URL.
+
+### 3. Navigate to the Worktree
 
 ```
 cd /path/to/worktree
 ```
 
-Switch to the worktree directory that was created by `generate_workplan`.
+Switch to the worktree directory that was created by `create_worktree`.
 
-### 3. View the workplan (if needed)
+### 4. View the workplan (if needed)
 
 You have two options to view a workplan:
 
@@ -161,7 +170,7 @@ Please retrieve the workplan for issue #123.
 
 This will use the `get_workplan` tool to fetch the latest content of the GitHub issue.
 
-### 4. Make Changes and Create a PR
+### 5. Make Changes and Create a PR
 
 After making changes to implement the workplan, create a PR using your preferred method:
 
@@ -175,7 +184,7 @@ git push origin HEAD
 gh pr create --title "Implement User Authentication" --body "This PR adds JWT authentication with bcrypt password hashing."
 ```
 
-### 5. Request a Review
+### 6. Request a Review
 
 Once your PR is created, you can request a review against the original workplan. You have two options:
 
@@ -197,7 +206,7 @@ This will use the `review_workplan` tool to fetch the original workplan from the
 
 ### generate_workplan
 
-Creates a GitHub issue with a detailed workplan based on the title and detailed description. The issue is labeled with 'yellhorn-mcp' and the plan is generated asynchronously, with the issue being updated once it's ready. Also creates a Git worktree with a linked branch for isolated development.
+Creates a GitHub issue with a detailed workplan based on the title and detailed description. The issue is labeled with 'yellhorn-mcp' and the plan is generated asynchronously, with the issue being updated once it's ready.
 
 **Input**:
 
@@ -208,7 +217,22 @@ Creates a GitHub issue with a detailed workplan based on the title and detailed 
 
 - JSON string containing:
   - `issue_url`: URL to the created GitHub issue
+  - `issue_number`: The GitHub issue number
+
+### create_worktree
+
+Creates a git worktree with a linked branch for isolated development from an existing workplan issue.
+
+**Input**:
+
+- `issue_number`: The GitHub issue number for the workplan
+
+**Output**:
+
+- JSON string containing:
   - `worktree_path`: Path to the created Git worktree directory
+  - `branch_name`: Name of the branch created for the worktree
+  - `issue_url`: URL to the associated GitHub issue
 
 ### get_workplan
 
@@ -297,6 +321,11 @@ curl -X POST http://127.0.0.1:8000/tools/generate_workplan \
   -H "Content-Type: application/json" \
   -d '{"title": "User Authentication System", "detailed_description": "Implement a secure authentication system using JWT tokens and bcrypt for password hashing"}'
 
+# Call a tool (create_worktree)
+curl -X POST http://127.0.0.1:8000/tools/create_worktree \
+  -H "Content-Type: application/json" \
+  -d '{"issue_number": "123"}'
+
 # Call a tool (get_workplan) from a worktree directory
 curl -X POST http://127.0.0.1:8000/tools/get_workplan \
   -H "Content-Type: application/json" \
@@ -328,6 +357,9 @@ python -m examples.client_example list
 
 # Generate a workplan
 python -m examples.client_example plan --title "User Authentication System" --description "Implement a secure authentication system using JWT tokens and bcrypt for password hashing"
+
+# Create a worktree for an existing workplan issue
+python -m examples.client_example worktree --issue-number "123"
 
 # Get workplan (from worktree directory)
 python -m examples.client_example getplan

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -750,10 +750,25 @@ async def test_process_workplan_async(mock_request_context, mock_genai_client):
         mock_genai_client.aio.models.generate_content.assert_called_once()
         args, kwargs = mock_genai_client.aio.models.generate_content.call_args
         assert kwargs.get("model") == "gemini-model"
-        assert "<title>" in kwargs.get("contents", "")
-        assert "Feature Implementation Plan" in kwargs.get("contents", "")
-        assert "<detailed_description>" in kwargs.get("contents", "")
-        assert "Create a new feature to support X" in kwargs.get("contents", "")
+
+        # Check basic prompt content
+        prompt_content = kwargs.get("contents", "")
+        assert "<title>" in prompt_content
+        assert "Feature Implementation Plan" in prompt_content
+        assert "<detailed_description>" in prompt_content
+        assert "Create a new feature to support X" in prompt_content
+
+        # Check for sub-LLM guidance content
+        assert "## Instructions for Workplan Structure" in prompt_content
+        assert 'ALWAYS start your workplan with a "## Summary" section' in prompt_content
+        assert "guide a sub-LLM that needs to understand the workplan" in prompt_content
+        assert "## Implementation Steps" in prompt_content
+        assert "## Technical Details" in prompt_content
+        assert "## Files to Modify" in prompt_content
+        assert (
+            "without additional context, and structured in a way that makes it easy for an LLM"
+            in prompt_content
+        )
 
         # Check that the issue was updated with the workplan including the title
         mock_update.assert_called_once()

--- a/yellhorn_mcp/server.py
+++ b/yellhorn_mcp/server.py
@@ -576,11 +576,26 @@ Your response will be published directly to a GitHub issue without modification,
 - Checkboxes for action items that can be marked as completed
 - Any relevant diagrams or explanations
 
-At the beginning of your workplan, include a section titled "## Summary" with a brief overview of
-the implementation approach. Keep the summary concise (3-5 sentences) so that an LLM can quickly
-understand what the workplan is about without parsing the entire detailed implementation plan.
+## Instructions for Workplan Structure
 
-The workplan should be comprehensive enough that a developer or AI assistant could implement it without additional context.
+1. ALWAYS start your workplan with a "## Summary" section that provides a concise overview of the implementation approach (3-5 sentences max). This summary should:
+   - State what will be implemented
+   - Outline the general approach
+   - Mention key files/components affected
+   - Be focused enough to guide a sub-LLM that needs to understand the workplan without parsing the entire document
+
+2. After the summary, include these clearly demarcated sections:
+   - "## Implementation Steps" - A numbered or bulleted list of specific tasks
+   - "## Technical Details" - Explanations of key design decisions and important considerations
+   - "## Files to Modify" - List of existing files that will need changes, with brief descriptions
+   - "## New Files to Create" - If applicable, list new files with their purpose
+
+3. For each implementation step or file modification, include:
+   - The specific code changes using formatted code blocks with syntax highlighting
+   - Explanations of WHY each change is needed, not just WHAT to change
+   - Detailed context that would help a less-experienced developer or LLM understand the change
+
+The workplan should be comprehensive enough that a developer or AI assistant could implement it without additional context, and structured in a way that makes it easy for an LLM to quickly understand and work with the contained information.
 """
         await ctx.log(
             level="info",


### PR DESCRIPTION
… worktree management

- Split generate_workplan tool to only create GitHub issues
- Added new create_worktree tool for Git worktree management
- Modified workplan generation prompt to include summary section
- Updated documentation and tests to reflect the new workflow
- Updated client example to demonstrate two-step workflow