### PR TITLE
Update models, rename review to judge, and add changelog for v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.6] - 2025-04-18
+
+### Changed
+- Default Gemini model updated to `gemini-2.5-pro-preview-03-25`.
+- Renamed "review" functionality to "judge" across the application (functions, MCP tool, GitHub labels, resource types, documentation) for better semantic alignment with AI evaluation tasks. The MCP tool is now `judge_workplan`. The associated GitHub label is now `yellhorn-judgement-subissue`. The resource type is now `yellhorn_judgement_subissue`.
+
+### Added
+- Added `gemini-2.5-flash-preview-04-17` as an available model option.
+- Added `CHANGELOG.md` to track changes.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A Model Context Protocol (MCP) server that exposes Gemini 2.5 Pro capabilities t
 ## Features
 
 - **Create Workplans**: Creates detailed implementation plans based on a prompt and taking into consideration your entire codebase, posting them as GitHub issues and exposing them as MCP resources for your coding agent
-- **Review Code Diffs**: Provides a tool to evaluate git diffs against the original workplan with full codebase context and provides detailed feedback, ensuring the implementation does not deviate from the original requirements and providing guidance on what to change to do so
+- **Judge Code Diffs**: Provides a tool to evaluate git diffs against the original workplan with full codebase context and provides detailed feedback, ensuring the implementation does not deviate from the original requirements and providing guidance on what to change to do so
 - **Isolated Development Environments**: Creates Git worktrees and linked branches for streamlined, isolated development workflow (can be done separately from workplan generation), allowing parallel development with multiple agents
-- **Seamless GitHub Integration**: Automatically creates labeled issues with proper branch linking in the GitHub UI, posts reviews subissues with references to original workplan issues.
+- **Seamless GitHub Integration**: Automatically creates labeled issues with proper branch linking in the GitHub UI, posts judgement sub-issues with references to original workplan issues.
 - **Context Control**: Use `.yellhornignore` files to exclude specific files and directories from the AI context, similar to `.gitignore`
 - **MCP Resources**: Exposes workplans as standard MCP resources for easy listing and retrieval
 
@@ -31,7 +31,7 @@ The server requires the following environment variables:
 
 - `GEMINI_API_KEY`: Your Gemini API key (required)
 - `REPO_PATH`: Path to your repository (defaults to current directory)
-- `YELLHORN_MCP_MODEL`: Gemini model to use (defaults to "gemini-2.5-pro-exp-03-25")
+- `YELLHORN_MCP_MODEL`: Gemini model to use (defaults to "gemini-2.5-pro-preview-03-25"). You can also use "gemini-2.5-flash-preview-04-17" for lower latency.
 
 The server also requires the GitHub CLI (`gh`) to be installed and authenticated.
 
@@ -92,7 +92,7 @@ When working with Claude Code, you can use the Yellhorn MCP tools by:
    gh pr create --title "[PR Title]" --body "[PR Description]"
    
    # You can run this from anywhere
-   Please review the PR comparing "main" and "feature-branch" against the workplan in issue #123
+   Please judge the PR comparing "main" and "feature-branch" against the workplan in issue #123
    ```
 
 ## Tools
@@ -139,9 +139,9 @@ Retrieves the workplan content (GitHub issue body) associated with a workplan.
 
 - The content of the workplan issue as a string
 
-### review_workplan
+### judge_workplan
 
-Triggers an asynchronous code review comparing two git refs (branches or commits) against a workplan described in a GitHub issue. Creates a GitHub sub-issue with the review asynchronously after running (in the background).
+Triggers an asynchronous code judgement comparing two git refs (branches or commits) against a workplan described in a GitHub issue. Creates a GitHub sub-issue with the judgement asynchronously after running (in the background).
 
 **Input**:
 
@@ -151,7 +151,7 @@ Triggers an asynchronous code review comparing two git refs (branches or commits
 
 **Output**:
 
-- A confirmation message that the review task has been initiated
+- A confirmation message that the judgement task has been initiated
 
 ## Resource Access
 
@@ -195,10 +195,13 @@ The project uses GitHub Actions for continuous integration and deployment:
 
 To release a new version:
 
-1. Update version in pyproject.toml
-2. Commit changes: `git commit -am "Bump version to X.Y.Z"`
-3. Tag the commit: `git tag vX.Y.Z`
-4. Push changes and tag: `git push && git push --tags`
+1. Update version in pyproject.toml and yellhorn_mcp/__init__.py
+2. Update CHANGELOG.md with the new changes
+3. Commit changes: `git commit -am "Bump version to X.Y.Z"`
+4. Tag the commit: `git tag vX.Y.Z`
+5. Push changes and tag: `git push && git push --tags`
+
+For a history of changes, see the [Changelog](CHANGELOG.md).
 
 For more detailed instructions, see the [Usage Guide](docs/USAGE.md).
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7,7 +7,7 @@ Yellhorn MCP is a Model Context Protocol (MCP) server that allows Claude Code to
 1. **Create workplan**: Creates a GitHub issue with a detailed implementation plan based on your codebase and task description.
 2. **Create worktree**: Creates a git worktree with a linked branch for isolated development from an existing workplan issue.
 3. **Get workplan**: Retrieves the workplan content from a worktree's associated GitHub issue.
-4. **Review workplan**: Triggers an asynchronous code review for a Pull Request against its original workplan issue.
+4. **Judge workplan**: Triggers an asynchronous code judgement for a Pull Request against its original workplan issue.
 
 ## Installation
 
@@ -27,7 +27,7 @@ The server requires the following environment variables:
 
 - `GEMINI_API_KEY` (required): Your Gemini API key
 - `REPO_PATH` (optional): Path to your Git repository (defaults to current directory)
-- `YELLHORN_MCP_MODEL` (optional): Gemini model to use (defaults to "gemini-2.5-pro-exp-03-25")
+- `YELLHORN_MCP_MODEL` (optional): Gemini model to use (defaults to "gemini-2.5-pro-preview-03-25"). You can also use "gemini-2.5-flash-preview-04-17" for lower latency.
 
 ### Excludes with .yellhornignore
 
@@ -79,7 +79,7 @@ gh auth login
 # Set environment variables
 export GEMINI_API_KEY=your_api_key_here
 export REPO_PATH=/path/to/your/repo
-export YELLHORN_MCP_MODEL=gemini-2.5-pro-exp-03-25
+export YELLHORN_MCP_MODEL=gemini-2.5-pro-preview-03-25
 ```
 
 ## Running the Server
@@ -96,7 +96,7 @@ yellhorn-mcp --repo-path /path/to/repo --host 127.0.0.1 --port 8000
 Available command-line options:
 
 - `--repo-path`: Path to the Git repository (defaults to current directory or REPO_PATH env var)
-- `--model`: Gemini model to use (defaults to "gemini-2.5-pro-exp-03-25" or YELLHORN_MCP_MODEL env var)
+- `--model`: Gemini model to use (defaults to "gemini-2.5-pro-preview-03-25" or YELLHORN_MCP_MODEL env var)
 - `--host`: Host to bind the server to (defaults to 127.0.0.1)
 - `--port`: Port to bind the server to (defaults to 8000)
 
@@ -177,16 +177,16 @@ git push origin HEAD
 gh pr create --title "Implement User Authentication" --body "This PR adds JWT authentication with bcrypt password hashing."
 ```
 
-### 6. Request a Review
+### 6. Request a Judgement
 
-Once your PR is created, you can request a review against the original workplan:
+Once your PR is created, you can request a judgement against the original workplan:
 
 ```
 # You can run this from anywhere
-Please review the PR comparing "main" and "feature-branch" against the workplan in issue #456.
+Please judge the PR comparing "main" and "feature-branch" against the workplan in issue #456.
 ```
 
-This will use the `review_workplan` tool to fetch the original workplan from the specified GitHub issue, generate a diff between the specified git references, and trigger an asynchronous review. The review will be posted as a GitHub sub-issue linked to the original workplan.
+This will use the `judge_workplan` tool to fetch the original workplan from the specified GitHub issue, generate a diff between the specified git references, and trigger an asynchronous judgement. The judgement will be posted as a GitHub sub-issue linked to the original workplan.
 
 ## MCP Tools
 
@@ -232,9 +232,9 @@ Retrieves the workplan content (GitHub issue body) associated with a workplan.
 
 - The content of the workplan issue as a string
 
-### review_workplan
+### judge_workplan
 
-Triggers an asynchronous code review comparing two git refs (branches or commits) against a workplan described in a GitHub issue. Creates a GitHub sub-issue with the review asynchronously after running (in the background).
+Triggers an asynchronous code judgement comparing two git refs (branches or commits) against a workplan described in a GitHub issue. Creates a GitHub sub-issue with the judgement asynchronously after running (in the background).
 
 **Input**:
 
@@ -244,7 +244,7 @@ Triggers an asynchronous code review comparing two git refs (branches or commits
 
 **Output**:
 
-- A confirmation message that the review task has been initiated
+- A confirmation message that the judgement task has been initiated
 
 ## MCP Resources
 
@@ -318,8 +318,8 @@ curl -X POST http://127.0.0.1:8000/tools/get_workplan \
   -H "Content-Type: application/json" \
   -d '{"issue_number": "123"}'
 
-# Call a tool (review_workplan)
-curl -X POST http://127.0.0.1:8000/tools/review_workplan \
+# Call a tool (judge_workplan)
+curl -X POST http://127.0.0.1:8000/tools/judge_workplan \
   -H "Content-Type: application/json" \
   -d '{"issue_number": "456", "base_ref": "main", "head_ref": "feature-branch"}'
 ```
@@ -341,8 +341,8 @@ python -m examples.client_example worktree --issue-number "123"
 # Get workplan
 python -m examples.client_example getplan --issue-number "123"
 
-# Review work
-python -m examples.client_example review --issue-number "456" --base-ref "main" --head-ref "feature-branch"
+# Judge work
+python -m examples.client_example judge --issue-number "456" --base-ref "main" --head-ref "feature-branch"
 ```
 
 The example client uses the MCP client API to interact with the server through stdio transport, which is the same approach Claude Code uses.
@@ -442,7 +442,7 @@ The publishing workflow will automatically run when the tag is pushed, building 
 
 For advanced use cases, you can modify the server's behavior by editing the source code:
 
-- Adjust the prompt templates in `process_workplan_async` and `process_review_async` functions
+- Adjust the prompt templates in `process_workplan_async` and `process_judgement_async` functions
 - Modify the codebase preprocessing in `get_codebase_snapshot` and `format_codebase_for_prompt`
 - Change the Gemini model version with the `YELLHORN_MCP_MODEL` environment variable
 

--- a/examples/client_example.py
+++ b/examples/client_example.py
@@ -8,7 +8,7 @@ similar to how Claude Code would call the MCP tools. It provides command-line in
 2. Generating workplans (creates GitHub issues)
 3. Creating worktrees for existing workplans
 4. Getting workplans from a worktree
-5. Reviewing completed work (adds reviews to PRs)
+5. Judging completed work (adds judgements to PRs)
 
 This client uses the MCP client API to interact with the server through stdio transport,
 which is the same approach Claude Code uses.
@@ -96,17 +96,17 @@ async def get_workplan(
     return result
 
 
-async def review_workplan(
+async def judge_workplan(
     session: ClientSession,
     issue_number: str,
     base_ref: str = "main",
     head_ref: str = "HEAD",
 ) -> str:
     """
-    Trigger a review comparing two git refs against the original workplan.
+    Trigger a judgement comparing two git refs against the original workplan.
 
-    This function calls the review_workplan tool to fetch the original workplan,
-    generate a diff between the git refs, and trigger an asynchronous review.
+    This function calls the judge_workplan tool to fetch the original workplan,
+    generate a diff between the git refs, and trigger an asynchronous judgement.
 
     Args:
         session: MCP client session.
@@ -115,13 +115,13 @@ async def review_workplan(
         head_ref: Head Git ref (commit SHA, branch name, tag) for comparison. Defaults to 'HEAD'.
 
     Returns:
-        A confirmation message that the review task has been initiated.
+        A confirmation message that the judgement task has been initiated.
     """
     # Prepare arguments
     arguments = {"issue_number": issue_number, "base_ref": base_ref, "head_ref": head_ref}
 
-    # Call the review_workplan tool
-    result = await session.call_tool("review_workplan", arguments=arguments)
+    # Call the judge_workplan tool
+    result = await session.call_tool("judge_workplan", arguments=arguments)
     return result
 
 
@@ -223,19 +223,19 @@ async def run_client(command: str, args: argparse.Namespace) -> None:
                     print(f"Error: {str(e)}")
                     sys.exit(1)
 
-            elif command == "review":
-                # Review work
-                print(f"Triggering review comparing {args.base_ref}..{args.head_ref}")
+            elif command == "judge":
+                # Judge work
+                print(f"Triggering judgement comparing {args.base_ref}..{args.head_ref}")
                 print(f"For workplan issue: {args.issue_number}")
 
                 try:
-                    result = await review_workplan(
+                    result = await judge_workplan(
                         session, args.issue_number, args.base_ref, args.head_ref
                     )
-                    print("\nReview Task:")
+                    print("\nJudgement Task:")
                     print(result)
                     print(
-                        "\nA review will be generated asynchronously and posted as a GitHub sub-issue."
+                        "\nA judgement will be generated asynchronously and posted as a GitHub sub-issue."
                     )
                 except Exception as e:
                     print(f"Error: {str(e)}")
@@ -290,24 +290,24 @@ def main():
         help="GitHub issue number for the workplan",
     )
 
-    # Review work command
-    review_parser = subparsers.add_parser(
-        "review", help="Trigger a review comparing two git refs against the workplan"
+    # Judge work command
+    judge_parser = subparsers.add_parser(
+        "judge", help="Trigger a judgement comparing two git refs against the workplan"
     )
-    review_parser.add_argument(
+    judge_parser.add_argument(
         "--issue-number",
         dest="issue_number",
         required=True,
         help="GitHub issue number for the workplan",
     )
-    review_parser.add_argument(
+    judge_parser.add_argument(
         "--base-ref",
         dest="base_ref",
         required=False,
         default="main",
         help="Base Git ref (commit SHA, branch name, tag) for comparison (default: 'main')",
     )
-    review_parser.add_argument(
+    judge_parser.add_argument(
         "--head-ref",
         dest="head_ref",
         required=False,
@@ -326,7 +326,7 @@ def main():
         "plan",
         "worktree",
         "getplan",
-        "review",
+        "judge",
     ]:
         print("Error: GEMINI_API_KEY environment variable is not set")
         print("Please set the GEMINI_API_KEY environment variable with your Gemini API key")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yellhorn-mcp"
-version = "0.2.5"
+version = "0.2.6"
 authors = [{ name = "Author" }]
 description = "Yellhorn offers MCP tools to generate detailed workplans with Gemini 2.5 Pro and to review diffs against them using your entire codebase as context."
 readme = "README.md"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ def test_main_success(
     mock_getenv.side_effect = lambda x, default=None: {
         "GEMINI_API_KEY": "mock-api-key",
         "REPO_PATH": "/mock/repo",
-        "YELLHORN_MCP_MODEL": "mock-model",
+        "YELLHORN_MCP_MODEL": "gemini-2.5-pro-preview-03-25",
     }.get(x, default)
 
     # Mock path checks
@@ -45,7 +45,7 @@ def test_main_success(
         # Check that a message was printed to stdout
         captured = capsys.readouterr()
         assert "Repository path: /mock/repo" in captured.out
-        assert "Using model: mock-model" in captured.out
+        assert "Using model: gemini-2.5-pro-preview-03-25" in captured.out
 
         # Check that sys.exit was not called
         mock_exit.assert_not_called()

--- a/yellhorn_mcp/__init__.py
+++ b/yellhorn_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Yellhorn MCP server for Claude Code to interact with the Gemini 2.5 Pro API."""
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/yellhorn_mcp/cli.py
+++ b/yellhorn_mcp/cli.py
@@ -35,8 +35,8 @@ def main():
     parser.add_argument(
         "--model",
         dest="model",
-        default=os.getenv("YELLHORN_MCP_MODEL", "gemini-2.5-pro-exp-03-25"),
-        help="Gemini model to use (default: gemini-2.5-pro-exp-03-25 or YELLHORN_MCP_MODEL)",
+        default=os.getenv("YELLHORN_MCP_MODEL", "gemini-2.5-pro-preview-03-25"),
+        help="Gemini model to use (e.g., gemini-2.5-pro-preview-03-25, gemini-2.5-flash-preview-04-17). Default: gemini-2.5-pro-preview-03-25 or YELLHORN_MCP_MODEL env var.",
     )
 
     parser.add_argument(


### PR DESCRIPTION
- Update default Gemini model to gemini-2.5-pro-preview-03-25
- Add gemini-2.5-flash-preview-04-17 as an option
- Rename review functionality to judge for better semantic alignment
- Create CHANGELOG.md to track changes
- Bump version number to 0.2.6