### PR TITLE
Add codebase_reasoning parameter to create_workplan tool

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -15,6 +15,10 @@
         "GEMINI_API_KEY": "${input:gemini-api-key}",
         "REPO_PATH": "${workspaceFolder}"
       }
+    },
+    "datapilot": {
+      "url": "http://localhost:7700/sse",
+      "type": "sse"
     }
   }
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -15,10 +15,6 @@
         "GEMINI_API_KEY": "${input:gemini-api-key}",
         "REPO_PATH": "${workspaceFolder}"
       }
-    },
-    "datapilot": {
-      "url": "http://localhost:7700/sse",
-      "type": "sse"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-04-28
+
+### Added
+
+- Add 'codebase_reasoning' parameter to create_workplan tool
+- Improved error handling on create_workplan
+
 ## [0.3.1] - 2025-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Creates a GitHub issue with a detailed workplan based on the title and detailed 
 
 - `title`: Title for the GitHub issue (will be used as issue title and header)
 - `detailed_description`: Detailed description for the workplan
+- `codebase_reasoning`: (optional) Control whether AI enhancement is performed:
+  - `"full"`: (default) Use AI to enhance the workplan with codebase context
+  - `"none"`: Skip AI enhancement, use the provided description as-is
 
 **Output**:
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -202,18 +202,25 @@ This will use the `judge_workplan` tool to fetch the original workplan from the 
 
 ### create_workplan
 
-Creates a GitHub issue with a detailed workplan based on the title and detailed description. The issue is labeled with 'yellhorn-mcp' and the plan is generated asynchronously, with the issue being updated once it's ready.
+Creates a GitHub issue with a detailed workplan based on the title and detailed description. The issue is labeled with 'yellhorn-mcp' and the plan is generated asynchronously (with `codebase_reasoning="full"`), with the issue being updated once it's ready. For faster creation without AI enhancement, use `codebase_reasoning="none"`.
 
 **Input**:
 
 - `title`: Title for the GitHub issue (will be used as issue title and header)
 - `detailed_description`: Detailed description for the workplan
+- `codebase_reasoning`: (optional) Control whether AI enhancement is performed:
+  - `"full"`: (default) Use AI to enhance the workplan with codebase context
+  - `"none"`: Skip AI enhancement, use the provided description as-is
 
 **Output**:
 
 - JSON string containing:
   - `issue_url`: URL to the created GitHub issue
   - `issue_number`: The GitHub issue number
+
+**Error Handling**:
+
+If AI enhancement fails when using `codebase_reasoning="full"`, a comment will be added to the issue with the error details, but the original issue body with title and description will be preserved.
 
 ### create_worktree
 
@@ -316,7 +323,12 @@ curl http://127.0.0.1:8000/tools
 # Call a tool (create_workplan)
 curl -X POST http://127.0.0.1:8000/tools/create_workplan \
   -H "Content-Type: application/json" \
-  -d '{"title": "User Authentication System", "detailed_description": "Implement a secure authentication system using JWT tokens and bcrypt for password hashing"}'
+  -d '{"title": "User Authentication System", "detailed_description": "Implement a secure authentication system using JWT tokens and bcrypt for password hashing", "codebase_reasoning": "full"}'
+
+# Call a tool (create_workplan without AI enhancement)
+curl -X POST http://127.0.0.1:8000/tools/create_workplan \
+  -H "Content-Type: application/json" \
+  -d '{"title": "User Authentication System", "detailed_description": "Implement a secure authentication system using JWT tokens and bcrypt for password hashing", "codebase_reasoning": "none"}'
 
 # Call a tool (create_worktree)
 curl -X POST http://127.0.0.1:8000/tools/create_worktree \
@@ -342,8 +354,11 @@ The package includes an example client that demonstrates how to interact with th
 # List available tools
 python -m examples.client_example list
 
-# Generate a workplan
+# Generate a workplan with AI enhancement (default)
 python -m examples.client_example plan --title "User Authentication System" --description "Implement a secure authentication system using JWT tokens and bcrypt for password hashing"
+
+# Generate a basic workplan without AI enhancement
+python -m examples.client_example plan --title "User Authentication System" --description "Implement a secure authentication system using JWT tokens and bcrypt for password hashing" --codebase-reasoning none
 
 # Create a worktree for an existing workplan issue
 python -m examples.client_example worktree --issue-number "123"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yellhorn-mcp"
-version = "0.3.1"
+version = "0.3.2"
 authors = [{ name = "Author" }]
 description = "Yellhorn offers MCP tools to generate detailed workplans with Gemini 2.5 Pro or OpenAI models and to review diffs against them using your entire codebase as context."
 readme = "README.md"

--- a/tests/test_mcp_annotations.py
+++ b/tests/test_mcp_annotations.py
@@ -44,6 +44,9 @@ def test_mcp_tool_signatures():
     assert "title" in signature.parameters
     assert "detailed_description" in signature.parameters
     assert "ctx" in signature.parameters
+    assert "codebase_reasoning" in signature.parameters
+    # Check that codebase_reasoning has a default value of "full"
+    assert signature.parameters["codebase_reasoning"].default == "full"
 
     # Test create_worktree parameters
     signature = inspect.signature(create_worktree)

--- a/yellhorn_mcp/__init__.py
+++ b/yellhorn_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Yellhorn MCP server for Claude Code to interact with the Gemini 2.5 Pro and OpenAI APIs."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/yellhorn_mcp/server.py
+++ b/yellhorn_mcp/server.py
@@ -547,6 +547,37 @@ async def ensure_label_exists(repo_path: Path, label: str, description: str = ""
         # This is non-critical, so we don't raise an exception
 
 
+async def add_github_issue_comment(repo_path: Path, issue_number: str, body: str) -> None:
+    """
+    Adds a comment to a specific GitHub issue.
+
+    Args:
+        repo_path: Path to the repository.
+        issue_number: The issue number to comment on.
+        body: The comment content to add.
+
+    Raises:
+        YellhornMCPError: If there's an error adding the comment.
+    """
+    try:
+        # Create a temporary file to hold the comment body
+        temp_file = repo_path / f"issue_{issue_number}_comment.md"
+        with open(temp_file, "w", encoding="utf-8") as f:
+            f.write(body)
+
+        try:
+            # Add the comment using the temp file
+            await run_github_command(
+                repo_path, ["issue", "comment", issue_number, "--body-file", str(temp_file)]
+            )
+        finally:
+            # Clean up the temp file
+            if temp_file.exists():
+                temp_file.unlink()
+    except Exception as e:
+        raise YellhornMCPError(f"Failed to add comment to GitHub issue: {str(e)}")
+
+
 async def update_github_issue(repo_path: Path, issue_number: str, body: str) -> None:
     """
     Update a GitHub issue with new content.
@@ -894,11 +925,16 @@ IMPORTANT: Respond *only* with the Markdown content for the GitHub issue body. D
 
         if not workplan_content:
             api_name = "OpenAI" if is_openai_model else "Gemini"
-            await update_github_issue(
-                repo_path,
-                issue_number,
-                f"Failed to generate workplan: Received an empty response from {api_name} API.",
+            error_message = (
+                f"Failed to generate workplan: Received an empty response from {api_name} API."
             )
+            await ctx.log(level="error", message=error_message)
+
+            # Add comment instead of overwriting
+            error_message_comment = (
+                f"⚠️ AI workplan enhancement failed: Received an empty response from {api_name} API."
+            )
+            await add_github_issue_comment(repo_path, issue_number, error_message_comment)
             return
 
         # Format metrics section
@@ -915,14 +951,17 @@ IMPORTANT: Respond *only* with the Markdown content for the GitHub issue body. D
         )
 
     except Exception as e:
-        error_message = f"Failed to generate workplan: {str(e)}"
-        await ctx.log(level="error", message=error_message)
+        error_message_log = f"Failed to generate workplan: {str(e)}"
+        await ctx.log(level="error", message=error_message_log)
+
+        # Add a comment to the GitHub issue instead of overwriting the body
+        error_message_comment = f"⚠️ AI workplan enhancement failed:\n\n```\n{str(e)}\n```\n\nThe original description provided remains in the issue body."
         try:
-            await update_github_issue(repo_path, issue_number, f"Error: {error_message}")
-        except Exception as update_error:
+            await add_github_issue_comment(repo_path, issue_number, error_message_comment)
+        except Exception as comment_error:
             await ctx.log(
                 level="error",
-                message=f"Failed to update GitHub issue with error: {str(update_error)}",
+                message=f"Additionally failed to add error comment to issue #{issue_number}: {str(comment_error)}",
             )
 
 
@@ -1120,12 +1159,13 @@ async def generate_branch_name(title: str, issue_number: str) -> str:
 
 @mcp.tool(
     name="create_workplan",
-    description="Create a detailed workplan for implementing a task based on the current codebase. Creates a GitHub issue with customizable title and detailed description, labeled with 'yellhorn-mcp'.",
+    description="Create a detailed workplan for implementing a task based on the current codebase. Creates a GitHub issue with customizable title and detailed description, labeled with 'yellhorn-mcp'. Control AI enhancement with the 'codebase_reasoning' parameter ('full' or 'none').",
 )
 async def create_workplan(
     title: str,
     detailed_description: str,
     ctx: Context,
+    codebase_reasoning: str = "full",
 ) -> str:
     """
     Create a workplan based on the provided title and detailed description.
@@ -1135,6 +1175,9 @@ async def create_workplan(
         title: Title for the GitHub issue (will be used as issue title and header).
         detailed_description: Detailed description for the workplan.
         ctx: Server context with repository path and model.
+        codebase_reasoning: Control whether AI enhancement is performed:
+            - "full": (default) Use AI to enhance the workplan with codebase context
+            - "none": Skip AI enhancement, use the provided description as-is
 
     Returns:
         JSON string containing the GitHub issue URL.
@@ -1151,8 +1194,15 @@ async def create_workplan(
         # Ensure the yellhorn-mcp label exists
         await ensure_label_exists(repo_path, "yellhorn-mcp", "Issues created by yellhorn-mcp")
 
-        # Prepare initial body with the title and detailed description
-        initial_body = f"# {title}\n\n## Description\n{detailed_description}\n\n*Generating detailed workplan, please wait...*"
+        # Prepare initial body based on reasoning mode
+        if codebase_reasoning == "none":
+            initial_body = f"# {title}\n\n## Description\n{detailed_description}"
+            await ctx.log(
+                level="info",
+                message="Skipping AI workplan enhancement as per codebase_reasoning='none'.",
+            )
+        else:  # Default is "full"
+            initial_body = f"# {title}\n\n## Description\n{detailed_description}\n\n*Generating detailed workplan using '{model}' with full codebase context, please wait...*"
 
         # Create a GitHub issue with the yellhorn-mcp label
         issue_url = await run_github_command(
@@ -1176,19 +1226,29 @@ async def create_workplan(
         )
         issue_number = issue_url.split("/")[-1]
 
-        # Start async processing
-        asyncio.create_task(
-            process_workplan_async(
-                repo_path,
-                gemini_client,
-                openai_client,
-                model,
-                title,
-                issue_number,
-                ctx,
-                detailed_description=detailed_description,
+        # Only start async processing if full reasoning is requested
+        if codebase_reasoning == "full":
+            await ctx.log(
+                level="info",
+                message=f"Initiating AI workplan enhancement for issue #{issue_number}.",
             )
-        )
+            asyncio.create_task(
+                process_workplan_async(
+                    repo_path,
+                    gemini_client,
+                    openai_client,
+                    model,
+                    title,
+                    issue_number,
+                    ctx,
+                    detailed_description=detailed_description,
+                )
+            )
+        else:
+            await ctx.log(
+                level="info",
+                message=f"Created basic workplan issue #{issue_number} without AI enhancement.",
+            )
 
         # Return the issue URL as JSON
         result = {


### PR DESCRIPTION
## Summary
- Added 'codebase_reasoning' parameter to control AI enhancement in create_workplan
- Added error handling for failed AI enhancement that preserves original issue content

## Test plan
- Verify create_workplan works with codebase_reasoning="full" (default)
- Verify create_workplan works with codebase_reasoning="none" 
- Verify error handling adds comments instead of overwriting issue body

🤖 Generated with [Claude Code](https://claude.ai/code)