### PR TITLE
Add metadata comments to workplan and judgment issues

### DIFF
--- a/tests/test_async_flows_openai.py
+++ b/tests/test_async_flows_openai.py
@@ -96,8 +96,8 @@ async def test_process_workplan_async_openai_errors(mock_openai_client):
 
         # Verify error was logged (check in all calls, not just the last one)
         error_call_found = any(
-            call.kwargs.get("level") == "error" and 
-            "Failed to generate workplan: OpenAI API error" in call.kwargs.get("message", "")
+            call.kwargs.get("level") == "error"
+            and "Failed to generate workplan: OpenAI API error" in call.kwargs.get("message", "")
             for call in mock_ctx.log.call_args_list
         )
         assert error_call_found, "Error log not found in log calls"
@@ -221,8 +221,8 @@ async def test_process_judgement_async_openai_errors(mock_openai_client):
 
         # Verify error was logged (check in all calls, not just the last one)
         error_call_found = any(
-            call.kwargs.get("level") == "error" and 
-            "Failed to generate judgement: OpenAI API error" in call.kwargs.get("message", "")
+            call.kwargs.get("level") == "error"
+            and "Failed to generate judgement: OpenAI API error" in call.kwargs.get("message", "")
             for call in mock_ctx.log.call_args_list
         )
         assert error_call_found, "Error log not found in log calls"

--- a/tests/test_async_flows_openai.py
+++ b/tests/test_async_flows_openai.py
@@ -62,10 +62,12 @@ async def test_process_workplan_async_openai_errors(mock_openai_client):
             detailed_description="Test description",
         )
 
-        # Verify error was propagated to add_github_issue_comment
+        # Verify error was propagated to add_github_issue_comment with completion metadata
         mock_add_comment.assert_called_once()
         args = mock_add_comment.call_args[0]
-        assert "⚠️ AI workplan enhancement failed" in args[2]
+        # Now we expect a completion metadata comment with error status
+        assert "## ⚠️ Workplan generation failed" in args[2]
+        assert "### ⚠️ Warnings" in args[2]
 
     # Test with OpenAI API error
     with (
@@ -92,17 +94,21 @@ async def test_process_workplan_async_openai_errors(mock_openai_client):
             detailed_description="Test description",
         )
 
-        # Verify error was logged
-        mock_ctx.log.assert_called_with(
-            level="error", message="Failed to generate workplan: OpenAI API error"
+        # Verify error was logged (check in all calls, not just the last one)
+        error_call_found = any(
+            call.kwargs.get("level") == "error" and 
+            "Failed to generate workplan: OpenAI API error" in call.kwargs.get("message", "")
+            for call in mock_ctx.log.call_args_list
         )
+        assert error_call_found, "Error log not found in log calls"
 
-        # Verify comment was added with error message
+        # Verify comment was added with error message using completion metadata format
         mock_add_comment.assert_called_once()
         args = mock_add_comment.call_args[0]
         assert args[0] == Path("/mock/repo")
         assert args[1] == "123"
-        assert "⚠️ AI workplan enhancement failed" in args[2]
+        assert "## ⚠️ Workplan generation failed" in args[2]
+        assert "### ⚠️ Warnings" in args[2]
         assert "OpenAI API error" in args[2]
 
 
@@ -179,7 +185,7 @@ async def test_process_judgement_async_openai_errors(mock_openai_client):
                 "Diff content",
                 "main",
                 "HEAD",
-                None,  # subissue_to_update
+                "456",  # subissue_to_update
                 "123",  # parent_workplan_issue_number
                 mock_ctx,
             )
@@ -188,6 +194,7 @@ async def test_process_judgement_async_openai_errors(mock_openai_client):
     with (
         patch("yellhorn_mcp.server.get_codebase_snapshot") as mock_snapshot,
         patch("yellhorn_mcp.server.format_codebase_for_prompt") as mock_format,
+        patch("yellhorn_mcp.server.add_github_issue_comment") as mock_add_comment,
     ):
         mock_snapshot.return_value = (["file1.py"], {"file1.py": "content"})
         mock_format.return_value = "Formatted codebase"
@@ -207,15 +214,18 @@ async def test_process_judgement_async_openai_errors(mock_openai_client):
                 "Diff content",
                 "main",
                 "HEAD",
-                None,  # subissue_to_update
+                "456",  # subissue_to_update
                 "123",  # parent_workplan_issue_number
                 mock_ctx,
             )
 
-        # Verify error was logged
-        mock_ctx.log.assert_called_with(
-            level="error", message="Failed to generate judgement: OpenAI API error"
+        # Verify error was logged (check in all calls, not just the last one)
+        error_call_found = any(
+            call.kwargs.get("level") == "error" and 
+            "Failed to generate judgement: OpenAI API error" in call.kwargs.get("message", "")
+            for call in mock_ctx.log.call_args_list
         )
+        assert error_call_found, "Error log not found in log calls"
 
 
 @pytest.mark.asyncio

--- a/tests/test_comment_utils.py
+++ b/tests/test_comment_utils.py
@@ -1,0 +1,213 @@
+"""Unit tests for comment formatting utilities."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from yellhorn_mcp.comment_utils import (
+    extract_urls,
+    format_completion_comment,
+    format_submission_comment,
+)
+from yellhorn_mcp.metadata_models import CompletionMetadata, SubmissionMetadata
+
+
+class TestFormatSubmissionComment:
+    """Test cases for format_submission_comment function."""
+
+    def test_basic_submission_comment(self):
+        """Test formatting a basic submission comment."""
+        metadata = SubmissionMetadata(
+            status="Generating workplan...",
+            model_name="gemini-2.5-pro-preview-05-06",
+            search_grounding_enabled=True,
+            yellhorn_version="0.5.0",
+            submitted_urls=None,
+            codebase_reasoning_mode="full",
+            timestamp=datetime(2025, 1, 6, 12, 0, 0, tzinfo=timezone.utc),
+        )
+
+        result = format_submission_comment(metadata)
+
+        assert "## 🚀 Generating workplan..." in result
+        assert "**Model**: `gemini-2.5-pro-preview-05-06`" in result
+        assert "**Search Grounding**: ✅ Enabled" in result
+        assert "**Codebase Reasoning**: `full`" in result
+        assert "**Yellhorn Version**: `0.5.0`" in result
+        assert "**Submitted**: 2025-01-06 12:00:00 UTC" in result
+        assert "_This issue will be updated once generation is complete._" in result
+
+    def test_submission_comment_with_urls(self):
+        """Test formatting a submission comment with URLs."""
+        metadata = SubmissionMetadata(
+            status="Generating judgement...",
+            model_name="gpt-4o",
+            search_grounding_enabled=False,
+            yellhorn_version="0.5.0",
+            submitted_urls=["https://example.com/api-docs", "https://github.com/user/repo"],
+            codebase_reasoning_mode="lsp",
+            timestamp=datetime(2025, 1, 6, 12, 0, 0, tzinfo=timezone.utc),
+        )
+
+        result = format_submission_comment(metadata)
+
+        assert "## 🚀 Generating judgement..." in result
+        assert "**Model**: `gpt-4o`" in result
+        assert "**Search Grounding**: ❌ Disabled" in result
+        assert "**Referenced URLs**:" in result
+        assert "- https://example.com/api-docs" in result
+        assert "- https://github.com/user/repo" in result
+
+
+class TestFormatCompletionComment:
+    """Test cases for format_completion_comment function."""
+
+    def test_successful_completion_comment(self):
+        """Test formatting a successful completion comment with all fields."""
+        metadata = CompletionMetadata(
+            status="✅ Workplan generated successfully",
+            generation_time_seconds=42.5,
+            input_tokens=10000,
+            output_tokens=2000,
+            total_tokens=12000,
+            estimated_cost=0.1234,
+            model_version_used="gemini-2.5-pro-preview-05-06",
+            system_fingerprint=None,
+            search_results_used=5,
+            finish_reason="stop",
+            safety_ratings=[
+                {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "probability": "NEGLIGIBLE"}
+            ],
+            context_size_chars=50000,
+            warnings=None,
+            timestamp=datetime(2025, 1, 6, 12, 0, 42, tzinfo=timezone.utc),
+        )
+
+        result = format_completion_comment(metadata)
+
+        assert "## ✅ Workplan generated successfully" in result
+        assert "### Generation Details" in result
+        assert "**Time**: 42.5 seconds" in result
+        assert "**Completed**: 2025-01-06 12:00:42 UTC" in result
+        assert "**Model Version**: `gemini-2.5-pro-preview-05-06`" in result
+        assert "### Token Usage" in result
+        assert "**Input Tokens**: 10,000" in result
+        assert "**Output Tokens**: 2,000" in result
+        assert "**Total Tokens**: 12,000" in result
+        assert "**Estimated Cost**: $0.1234" in result
+        assert "**Search Results Used**: 5" in result
+        assert "**Context Size**: 50,000 characters" in result
+        assert "**Finish Reason**: `stop`" in result
+        assert "### Safety Ratings" in result
+        assert "- **HARM_CATEGORY_DANGEROUS_CONTENT**: NEGLIGIBLE" in result
+
+    def test_failed_completion_comment(self):
+        """Test formatting a failed completion comment."""
+        metadata = CompletionMetadata(
+            status="⚠️ Workplan generation failed",
+            generation_time_seconds=10.2,
+            input_tokens=None,
+            output_tokens=None,
+            total_tokens=None,
+            estimated_cost=None,
+            model_version_used=None,
+            system_fingerprint=None,
+            search_results_used=None,
+            finish_reason="error",
+            safety_ratings=None,
+            context_size_chars=None,
+            warnings=["API rate limit exceeded", "Please try again later"],
+            timestamp=datetime(2025, 1, 6, 12, 0, 10, tzinfo=timezone.utc),
+        )
+
+        result = format_completion_comment(metadata)
+
+        assert "## ⚠️ Workplan generation failed" in result
+        assert "**Time**: 10.2 seconds" in result
+        assert "**Finish Reason**: `error`" in result
+        assert "### ⚠️ Warnings" in result
+        assert "- API rate limit exceeded" in result
+        assert "- Please try again later" in result
+        # Ensure token usage section is not included when no tokens
+        assert "### Token Usage" not in result
+
+    def test_openai_completion_comment(self):
+        """Test formatting an OpenAI completion comment with system fingerprint."""
+        metadata = CompletionMetadata(
+            status="✅ Judgement generated successfully",
+            generation_time_seconds=35.8,
+            input_tokens=8000,
+            output_tokens=1500,
+            total_tokens=9500,
+            estimated_cost=0.0975,
+            model_version_used="gpt-4o-2024-01-01",
+            system_fingerprint="fp_abc123def456",
+            search_results_used=None,
+            finish_reason="stop",
+            safety_ratings=None,
+            context_size_chars=45000,
+            warnings=None,
+            timestamp=datetime(2025, 1, 6, 12, 0, 35, tzinfo=timezone.utc),
+        )
+
+        result = format_completion_comment(metadata)
+
+        assert "**System Fingerprint**: `fp_abc123def456`" in result
+        assert "**Search Results Used**:" not in result  # Should not show if None
+        assert "### Safety Ratings" not in result  # Should not show if None
+
+
+class TestExtractUrls:
+    """Test cases for extract_urls function."""
+
+    def test_extract_single_url(self):
+        """Test extracting a single URL from text."""
+        text = "Check out the documentation at https://example.com/docs for more info."
+        urls = extract_urls(text)
+        assert urls == ["https://example.com/docs"]
+
+    def test_extract_multiple_urls(self):
+        """Test extracting multiple URLs from text."""
+        text = """
+        Here are some useful resources:
+        - API docs: https://api.example.com/v2/docs
+        - GitHub repo: https://github.com/user/project
+        - Website: http://example.org
+        """
+        urls = extract_urls(text)
+        assert len(urls) == 3
+        assert "https://api.example.com/v2/docs" in urls
+        assert "https://github.com/user/project" in urls
+        assert "http://example.org" in urls
+
+    def test_extract_duplicate_urls(self):
+        """Test that duplicate URLs are deduplicated while preserving order."""
+        text = """
+        Visit https://example.com for info.
+        Also check https://github.com/repo and https://example.com again.
+        """
+        urls = extract_urls(text)
+        assert urls == ["https://example.com", "https://github.com/repo"]
+
+    def test_no_urls_in_text(self):
+        """Test handling text with no URLs."""
+        text = "This is just plain text without any URLs."
+        urls = extract_urls(text)
+        assert urls == []
+
+    def test_urls_with_special_characters(self):
+        """Test extracting URLs with query parameters and fragments."""
+        text = """
+        Search at https://example.com/search?q=python&limit=10
+        And bookmark https://docs.example.com/guide#section-2
+        """
+        urls = extract_urls(text)
+        assert len(urls) == 2
+        assert "https://example.com/search?q=python&limit=10" in urls
+        assert "https://docs.example.com/guide#section-2" in urls
+
+    def test_urls_in_parentheses(self):
+        """Test that URLs in parentheses are extracted correctly."""
+        text = "For more details (see https://example.com/details) contact support."
+        urls = extract_urls(text)
+        assert urls == ["https://example.com/details"]

--- a/tests/test_lsp_mode.py
+++ b/tests/test_lsp_mode.py
@@ -443,23 +443,25 @@ async def test_integration_process_judgement_lsp_mode():
                         )
 
                         with patch("yellhorn_mcp.server.update_github_issue") as mock_update_issue:
-                            with patch("yellhorn_mcp.server.add_github_issue_comment") as mock_add_comment:
+                            with patch(
+                                "yellhorn_mcp.server.add_github_issue_comment"
+                            ) as mock_add_comment:
 
                                 # Call the function with LSP mode
                                 result = await process_judgement_async(
-                                repo_path,
-                                gemini_client,
-                                None,  # No OpenAI client
-                                model,
-                                workplan,
-                                diff,
-                                base_ref,
-                                head_ref,
-                                "subissue-123",  # subissue_to_update
-                                issue_number,  # parent_workplan_issue_number
-                                ctx,
-                                codebase_reasoning="lsp",
-                            )
+                                    repo_path,
+                                    gemini_client,
+                                    None,  # No OpenAI client
+                                    model,
+                                    workplan,
+                                    diff,
+                                    base_ref,
+                                    head_ref,
+                                    "subissue-123",  # subissue_to_update
+                                    issue_number,  # parent_workplan_issue_number
+                                    ctx,
+                                    codebase_reasoning="lsp",
+                                )
 
                                 # Verify LSP snapshot was used
                                 mock_lsp_snapshot.assert_called_once_with(repo_path)

--- a/tests/test_lsp_mode.py
+++ b/tests/test_lsp_mode.py
@@ -394,6 +394,11 @@ async def test_integration_process_judgement_lsp_mode():
         "candidates_token_count": 500,
         "total_token_count": 1500,
     }
+    # Mock the candidates structure for Gemini models to avoid validation errors
+    response.candidates = [MagicMock()]
+    response.candidates[0].safety_ratings = []
+    response.candidates[0].finish_reason = MagicMock()
+    response.candidates[0].finish_reason.name = "STOP"
 
     # Set up both old and new API patterns for backward compatibility with tests
     gemini_client.aio.models.generate_content = AsyncMock(return_value=response)
@@ -438,9 +443,10 @@ async def test_integration_process_judgement_lsp_mode():
                         )
 
                         with patch("yellhorn_mcp.server.update_github_issue") as mock_update_issue:
+                            with patch("yellhorn_mcp.server.add_github_issue_comment") as mock_add_comment:
 
-                            # Call the function with LSP mode
-                            result = await process_judgement_async(
+                                # Call the function with LSP mode
+                                result = await process_judgement_async(
                                 repo_path,
                                 gemini_client,
                                 None,  # No OpenAI client
@@ -455,20 +461,20 @@ async def test_integration_process_judgement_lsp_mode():
                                 codebase_reasoning="lsp",
                             )
 
-                            # Verify LSP snapshot was used
-                            mock_lsp_snapshot.assert_called_once_with(repo_path)
+                                # Verify LSP snapshot was used
+                                mock_lsp_snapshot.assert_called_once_with(repo_path)
 
-                            # Verify diff files were processed
-                            mock_update_diff.assert_called_once_with(
-                                repo_path,
-                                base_ref,
-                                head_ref,
-                                ["file1.py"],
-                                {"file1.py": "```py\ndef function1()\n```"},
-                            )
+                                # Verify diff files were processed
+                                mock_update_diff.assert_called_once_with(
+                                    repo_path,
+                                    base_ref,
+                                    head_ref,
+                                    ["file1.py"],
+                                    {"file1.py": "```py\ndef function1()\n```"},
+                                )
 
-                            # Verify GitHub issue was updated
-                            mock_update_issue.assert_called_once()
+                                # Verify GitHub issue was updated
+                                mock_update_issue.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -39,6 +39,7 @@ def mock_openai_client():
     message = MagicMock()
     message.content = "Mock OpenAI response text"
     choice.message = message
+    choice.finish_reason = "stop"  # Add finish_reason as string
     response.choices = [choice]
 
     # Mock usage data
@@ -46,6 +47,10 @@ def mock_openai_client():
     response.usage.prompt_tokens = 1000
     response.usage.completion_tokens = 500
     response.usage.total_tokens = 1500
+    
+    # Mock model and system_fingerprint as strings
+    response.model = "gpt-4o-1234"
+    response.system_fingerprint = "fp_abc123"
 
     # Setup the chat.completions.create async method
     chat_completions.create = AsyncMock(return_value=response)
@@ -210,6 +215,7 @@ async def test_process_judgement_async_openai(mock_request_context, mock_openai_
         patch("yellhorn_mcp.server.format_codebase_for_prompt") as mock_format,
         patch("yellhorn_mcp.server.format_metrics_section") as mock_format_metrics,
         patch("yellhorn_mcp.server.update_github_issue") as mock_update_issue,
+        patch("yellhorn_mcp.server.add_github_issue_comment") as mock_add_comment,
     ):
         mock_snapshot.return_value = (["file1.py"], {"file1.py": "content"})
         mock_format.return_value = "Formatted codebase"

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -47,7 +47,7 @@ def mock_openai_client():
     response.usage.prompt_tokens = 1000
     response.usage.completion_tokens = 500
     response.usage.total_tokens = 1500
-    
+
     # Mock model and system_fingerprint as strings
     response.model = "gpt-4o-1234"
     response.system_fingerprint = "fp_abc123"

--- a/yellhorn_mcp/comment_utils.py
+++ b/yellhorn_mcp/comment_utils.py
@@ -1,0 +1,136 @@
+"""Utilities for formatting GitHub issue comments with metadata."""
+
+import re
+from datetime import datetime
+
+from yellhorn_mcp.metadata_models import CompletionMetadata, SubmissionMetadata
+
+
+def format_submission_comment(metadata: SubmissionMetadata) -> str:
+    """Format a submission metadata comment for GitHub issues.
+
+    Args:
+        metadata: The submission metadata to format.
+
+    Returns:
+        Formatted markdown string for the comment.
+    """
+    lines = [
+        f"## 🚀 {metadata.status}",
+        "",
+        f"**Model**: `{metadata.model_name}`  ",
+        f"**Search Grounding**: {'✅ Enabled' if metadata.search_grounding_enabled else '❌ Disabled'}  ",
+        f"**Codebase Reasoning**: `{metadata.codebase_reasoning_mode}`  ",
+        f"**Yellhorn Version**: `{metadata.yellhorn_version}`  ",
+        f"**Submitted**: {metadata.timestamp.strftime('%Y-%m-%d %H:%M:%S UTC')}  ",
+    ]
+
+    if metadata.submitted_urls:
+        lines.extend(
+            [
+                "",
+                "**Referenced URLs**:",
+                *[f"- {url}" for url in metadata.submitted_urls],
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            "---",
+            "_This issue will be updated once generation is complete._",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def format_completion_comment(metadata: CompletionMetadata) -> str:
+    """Format a completion metadata comment for GitHub issues.
+
+    Args:
+        metadata: The completion metadata to format.
+
+    Returns:
+        Formatted markdown string for the comment.
+    """
+    lines = [
+        f"## {metadata.status}",
+        "",
+        "### Generation Details",
+        f"**Time**: {metadata.generation_time_seconds:.1f} seconds  ",
+        f"**Completed**: {metadata.timestamp.strftime('%Y-%m-%d %H:%M:%S UTC')}  ",
+    ]
+
+    if metadata.model_version_used:
+        lines.append(f"**Model Version**: `{metadata.model_version_used}`  ")
+
+    if metadata.system_fingerprint:
+        lines.append(f"**System Fingerprint**: `{metadata.system_fingerprint}`  ")
+
+    # Token usage section
+    if any(
+        [
+            metadata.input_tokens,
+            metadata.output_tokens,
+            metadata.total_tokens,
+            metadata.estimated_cost,
+        ]
+    ):
+        lines.extend(["", "### Token Usage"])
+        if metadata.input_tokens is not None:
+            lines.append(f"**Input Tokens**: {metadata.input_tokens:,}  ")
+        if metadata.output_tokens is not None:
+            lines.append(f"**Output Tokens**: {metadata.output_tokens:,}  ")
+        if metadata.total_tokens is not None:
+            lines.append(f"**Total Tokens**: {metadata.total_tokens:,}  ")
+        if metadata.estimated_cost is not None:
+            lines.append(f"**Estimated Cost**: ${metadata.estimated_cost:.4f}  ")
+
+    # Additional details
+    if metadata.search_results_used is not None:
+        lines.extend(["", f"**Search Results Used**: {metadata.search_results_used}  "])
+
+    if metadata.context_size_chars is not None:
+        lines.append(f"**Context Size**: {metadata.context_size_chars:,} characters  ")
+
+    if metadata.finish_reason:
+        lines.append(f"**Finish Reason**: `{metadata.finish_reason}`  ")
+
+    # Safety ratings (if present)
+    if metadata.safety_ratings:
+        lines.extend(["", "### Safety Ratings"])
+        for rating in metadata.safety_ratings:
+            category = rating.get("category", "Unknown")
+            probability = rating.get("probability", "Unknown")
+            lines.append(f"- **{category}**: {probability}")
+
+    # Warnings
+    if metadata.warnings:
+        lines.extend(["", "### ⚠️ Warnings"])
+        for warning in metadata.warnings:
+            lines.append(f"- {warning}")
+
+    return "\n".join(lines)
+
+
+def extract_urls(text: str) -> list[str]:
+    """Extract URLs from text using a regular expression.
+
+    Args:
+        text: The text to extract URLs from.
+
+    Returns:
+        List of unique URLs found in the text.
+    """
+    # Regex pattern to match URLs
+    url_pattern = r"https?://[^\s()<>]+"
+    urls = re.findall(url_pattern, text)
+    # Return unique URLs while preserving order
+    seen = set()
+    unique_urls = []
+    for url in urls:
+        if url not in seen:
+            seen.add(url)
+            unique_urls.append(url)
+    return unique_urls

--- a/yellhorn_mcp/metadata_models.py
+++ b/yellhorn_mcp/metadata_models.py
@@ -1,0 +1,48 @@
+"""Metadata models for Yellhorn MCP GitHub issue comments."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SubmissionMetadata(BaseModel):
+    """Metadata for the initial submission comment when a workplan or judgement is requested."""
+
+    status: str = Field(description="Current status (e.g., 'Generating workplan...')")
+    model_name: str = Field(description="LLM model name being used")
+    search_grounding_enabled: bool = Field(description="Whether search grounding is enabled")
+    yellhorn_version: str = Field(description="Version of Yellhorn MCP")
+    submitted_urls: list[str] | None = Field(default=None, description="URLs found in the request")
+    codebase_reasoning_mode: str = Field(
+        description="The codebase reasoning mode (full, lsp, file_structure, none)"
+    )
+    timestamp: datetime = Field(description="Timestamp of submission")
+
+
+class CompletionMetadata(BaseModel):
+    """Metadata for the completion comment after LLM processing finishes."""
+
+    status: str = Field(
+        description="Completion status (e.g., '✅ Workplan generated successfully')"
+    )
+    generation_time_seconds: float = Field(description="Time taken for LLM generation")
+    input_tokens: int | None = Field(default=None, description="Number of input tokens")
+    output_tokens: int | None = Field(default=None, description="Number of output tokens")
+    total_tokens: int | None = Field(default=None, description="Total tokens used")
+    estimated_cost: float | None = Field(default=None, description="Estimated cost in USD")
+    model_version_used: str | None = Field(
+        default=None, description="Actual model version reported by API"
+    )
+    system_fingerprint: str | None = Field(default=None, description="OpenAI system fingerprint")
+    search_results_used: int | None = Field(
+        default=None, description="Number of search results used (Gemini)"
+    )
+    finish_reason: str | None = Field(default=None, description="LLM finish reason")
+    safety_ratings: list[dict] | None = Field(
+        default=None, description="Safety ratings from the model"
+    )
+    context_size_chars: int | None = Field(
+        default=None, description="Total characters in the prompt"
+    )
+    warnings: list[str] | None = Field(default=None, description="Any warnings to report")
+    timestamp: datetime = Field(description="Timestamp of completion")

--- a/yellhorn_mcp/server.py
+++ b/yellhorn_mcp/server.py
@@ -1175,10 +1175,15 @@ IMPORTANT: Respond *only* with the Markdown content for the GitHub issue body. D
             if hasattr(response.choices[0], "finish_reason"):
                 finish_reason = response.choices[0].finish_reason
         elif not is_openai_model and usage_metadata:
-            # Gemini usage format
-            input_tokens = usage_metadata.get("prompt_token_count")
-            output_tokens = usage_metadata.get("candidates_token_count")
-            total_tokens = usage_metadata.get("total_token_count")
+            # Gemini usage format - handle both dict and object forms
+            if isinstance(usage_metadata, dict):
+                input_tokens = usage_metadata.get("prompt_token_count")
+                output_tokens = usage_metadata.get("candidates_token_count")
+                total_tokens = usage_metadata.get("total_token_count")
+            else:
+                input_tokens = getattr(usage_metadata, "prompt_token_count", None)
+                output_tokens = getattr(usage_metadata, "candidates_token_count", None)
+                total_tokens = getattr(usage_metadata, "total_token_count", None)
             # Check for search results in grounding metadata
             if hasattr(response, "grounding_metadata") and response.grounding_metadata:
                 if hasattr(response.grounding_metadata, "search_entry_point"):
@@ -1553,10 +1558,15 @@ IMPORTANT: Respond *only* with the Markdown content for the judgement. Do *not* 
             if hasattr(response.choices[0], "finish_reason"):
                 finish_reason = response.choices[0].finish_reason
         elif not is_openai_model and usage_metadata:
-            # Gemini usage format
-            input_tokens = usage_metadata.get("prompt_token_count")
-            output_tokens = usage_metadata.get("candidates_token_count")
-            total_tokens = usage_metadata.get("total_token_count")
+            # Gemini usage format - handle both dict and object forms
+            if isinstance(usage_metadata, dict):
+                input_tokens = usage_metadata.get("prompt_token_count")
+                output_tokens = usage_metadata.get("candidates_token_count")
+                total_tokens = usage_metadata.get("total_token_count")
+            else:
+                input_tokens = getattr(usage_metadata, "prompt_token_count", None)
+                output_tokens = getattr(usage_metadata, "candidates_token_count", None)
+                total_tokens = getattr(usage_metadata, "total_token_count", None)
             # Check for search results in grounding metadata
             if hasattr(response, "grounding_metadata") and response.grounding_metadata:
                 if hasattr(response.grounding_metadata, "search_entry_point"):


### PR DESCRIPTION
## Summary
- Implements workplan #85 to enhance user experience by adding informative metadata comments
- Adds submission and completion comments with status updates, metrics, and configuration details
- Provides transparency into the LLM query process including token usage and costs

## Test plan
- [x] Run all unit tests: `python -m pytest`
- [x] Test create_workplan with metadata comments
- [x] Test judge_workplan with metadata comments
- [x] Test error handling with completion comments
- [x] Verify URL extraction from descriptions
- [x] Check comment formatting for both Gemini and OpenAI models

🤖 Generated with [Claude Code](https://claude.ai/code)