### PR TITLE
Add revise_workplan tool for updating existing workplans (#112)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,10 +3,7 @@
     "yellhorn-mcp": {
       "type": "stdio",
       "command": "yellhorn-mcp",
-      "args": [
-        "--model",
-        "o3-deep-research"
-      ],
+      "args": [],
       "env": {}
     }
   }

--- a/README.md
+++ b/README.md
@@ -128,6 +128,28 @@ Retrieves the workplan content (GitHub issue body) associated with a workplan.
 
 - The content of the workplan issue as a string
 
+### revise_workplan
+
+Updates an existing workplan based on revision instructions. The tool fetches the current workplan from the specified GitHub issue and uses AI to revise it according to your instructions.
+
+**Input**:
+
+- `issue_number`: The GitHub issue number containing the workplan to revise
+- `revision_instructions`: Instructions describing how to revise the workplan
+- `codebase_reasoning`: (optional) Control whether AI enhancement is performed:
+  - `"full"`: (default) Use AI to revise with full codebase context
+  - `"lsp"`: Use AI with lightweight codebase context (function/method signatures only)
+  - `"file_structure"`: Use AI with directory structure only (fastest)
+  - `"none"`: Minimal codebase context
+- `debug`: (optional) If set to `true`, adds a comment to the issue with the full prompt used for generation
+- `disable_search_grounding`: (optional) If set to `true`, disables Google Search Grounding for this request
+
+**Output**:
+
+- JSON string containing:
+  - `issue_url`: URL to the updated GitHub issue
+  - `issue_number`: The GitHub issue number
+
 ### judge_workplan
 
 Triggers an asynchronous code judgement comparing two git refs (branches or commits) against a workplan described in a GitHub issue. Creates a placeholder GitHub sub-issue immediately and then processes the AI judgement asynchronously, updating the sub-issue with results.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -290,6 +290,41 @@ Retrieves the workplan content (GitHub issue body) associated with a specified G
 
 - The content of the workplan issue as a string
 
+### revise_workplan
+
+Updates an existing workplan based on revision instructions. The tool fetches the current workplan from the specified GitHub issue and uses AI to revise it according to your instructions.
+
+**Input**:
+
+- `issue_number`: The GitHub issue number containing the workplan to revise
+- `revision_instructions`: Instructions describing how to revise the workplan (e.g., "Add more detail about testing", "Include database migration steps", "Update to use React instead of Vue")
+- `codebase_reasoning`: (optional) Control whether AI enhancement is performed:
+  - `"full"`: (default) Use AI to revise with full codebase context
+  - `"lsp"`: Use AI with lightweight codebase context (function/method signatures only)
+  - `"file_structure"`: Use AI with directory structure only (fastest)
+  - `"none"`: Minimal codebase context
+- `debug`: (optional) If set to `true`, adds a comment to the issue with the full prompt used for generation
+- `disable_search_grounding`: (optional) If set to `true`, disables Google Search Grounding for this request
+
+**Output**:
+
+- JSON string containing:
+  - `issue_url`: URL to the updated GitHub issue
+  - `issue_number`: The GitHub issue number
+
+**Example Usage**:
+
+```
+Please revise workplan #123 to include more detail about error handling and recovery mechanisms.
+```
+
+This will:
+1. Fetch the existing workplan from issue #123
+2. Add a submission comment indicating the revision is in progress
+3. Launch a background task to revise the workplan based on your instructions
+4. Update the issue with the revised workplan once complete
+5. Add a completion comment with metrics
+
 ### curate_context
 
 Analyzes the codebase structure to build a .yellhorncontext file with optimized directory filtering rules customized for your specific task. This tool creates a comprehensive context file that includes both blacklist/whitelist patterns to ensure the AI has access to the most relevant directories.
@@ -456,6 +491,11 @@ curl -X POST http://127.0.0.1:8000/tools/create_workplan \
 curl -X POST http://127.0.0.1:8000/tools/get_workplan \
   -H "Content-Type: application/json" \
   -d '{"issue_number": "123"}'
+
+# Call a tool (revise_workplan)
+curl -X POST http://127.0.0.1:8000/tools/revise_workplan \
+  -H "Content-Type: application/json" \
+  -d '{"issue_number": "123", "revision_instructions": "Add more detail about error handling and recovery mechanisms", "codebase_reasoning": "full"}'
 
 # Call a tool (curate_context)
 curl -X POST http://127.0.0.1:8000/tools/curate_context \


### PR DESCRIPTION
## Summary
- Implements a new `revise_workplan` tool that allows users to update existing workplans based on revision instructions
- Refactors shared functionality to reduce code duplication
- Adds comprehensive tests and documentation

## Implementation Details

This PR implements workplan #112 by adding a new tool that fetches an existing workplan from a GitHub issue and uses AI to revise it according to user-provided instructions.

### Key Changes:

1. **Refactored shared functionality** in `workplan_processor.py`:
   - Added `_get_codebase_context` helper function to consolidate codebase context retrieval logic
   - Added `_generate_and_update_issue` helper function to handle AI generation and issue updates
   - These refactorings reduce code duplication between `process_workplan_async` and the new `process_revision_async`

2. **Added `process_revision_async` function** that:
   - Fetches the original workplan content
   - Constructs a revision prompt with the original workplan and revision instructions
   - Uses the shared helpers to generate and update the issue

3. **Added `revise_workplan` tool** to `server.py` that:
   - Validates the issue exists and contains a workplan
   - Posts a submission comment indicating revision is in progress
   - Launches a background async task for the revision
   - Returns the issue URL and number immediately

4. **Comprehensive test coverage**:
   - Unit test in `test_server.py` for the `revise_workplan` tool endpoint
   - Integration tests in `test_async_flows_openai.py` for `process_revision_async`
   - Error handling test to ensure exceptions are properly caught and reported

5. **Updated documentation**:
   - Added tool description in README.md
   - Added detailed usage documentation in docs/USAGE.md with examples
   - Added curl example for direct API usage

## Test Plan
- [x] All existing tests pass
- [x] New unit tests for `revise_workplan` tool pass
- [x] New integration tests for `process_revision_async` pass
- [x] Code formatted with black and isort
- [x] Manual testing confirms the tool works as expected

## Related Issues
Closes #112

🤖 Generated with [Claude Code](https://claude.ai/code)